### PR TITLE
Revamp UI and add trip comparison map

### DIFF
--- a/assets/script.js
+++ b/assets/script.js
@@ -1,0 +1,466 @@
+const appsScriptUrl = 'https://script.google.com/macros/s/AKfycbzH67AeoCSPMdGa_apXqT3juZVGVWzdcVv5Qp6iZ27aWMk-PFgadloIum5TjBtFxBFE/exec';
+
+const toast = document.querySelector('.toast');
+const currentYearEl = document.getElementById('current-year');
+const successModal = document.getElementById('success-modal');
+const successMessageEl = document.getElementById('success-message');
+const modalBackdrop = document.querySelector('.modal-backdrop');
+const modalCloseButtons = document.querySelectorAll('[data-close-modal]');
+
+if (currentYearEl) {
+  currentYearEl.textContent = new Date().getFullYear();
+}
+
+const showToast = (message, isError = false) => {
+  if (!toast) return;
+  toast.textContent = message;
+  toast.classList.toggle('error', Boolean(isError));
+  toast.hidden = false;
+  setTimeout(() => {
+    toast.hidden = true;
+    toast.classList.remove('error');
+  }, 5000);
+};
+
+const openSuccessModal = (message) => {
+  if (!successModal || !modalBackdrop || !successMessageEl) {
+    showToast(message);
+    return;
+  }
+  successMessageEl.innerHTML = message;
+  modalBackdrop.hidden = false;
+  successModal.hidden = false;
+  successModal.focus({ preventScroll: true });
+};
+
+const closeSuccessModal = () => {
+  if (!successModal || !modalBackdrop) return;
+  modalBackdrop.hidden = true;
+  successModal.hidden = true;
+};
+
+modalCloseButtons.forEach((button) => {
+  button.addEventListener('click', () => closeSuccessModal());
+});
+
+if (modalBackdrop) {
+  modalBackdrop.addEventListener('click', () => closeSuccessModal());
+}
+
+document.addEventListener('keydown', (event) => {
+  if (event.key === 'Escape') {
+    closeSuccessModal();
+  }
+});
+
+const formatPhone = (value) => value.replace(/[^+\d]/g, '');
+
+const validateRequired = (input) => {
+  const id = input.id || input.name;
+  const errorEl = document.querySelector(`[data-error-for="${id}"]`);
+  let message = '';
+
+  if (input.type === 'radio') {
+    const checked = document.querySelector(`input[name="${input.name}"]:checked`);
+    if (!checked) {
+      message = 'Veuillez sélectionner une option.';
+    }
+  } else if (input.tagName === 'SELECT' && !input.value) {
+    message = 'Veuillez sélectionner une option.';
+  } else if (!input.value.trim()) {
+    message = 'Ce champ est obligatoire.';
+  } else if (input.type === 'tel' && input.pattern) {
+    const regex = new RegExp(input.pattern);
+    if (!regex.test(formatPhone(input.value))) {
+      message = 'Veuillez saisir un numéro de téléphone français valide.';
+    }
+  } else if (input.type === 'email') {
+    const emailRegex = /.+@.+\..+/;
+    if (!emailRegex.test(input.value.trim())) {
+      message = 'Veuillez saisir une adresse e-mail valide.';
+    }
+  }
+
+  if (errorEl) {
+    errorEl.textContent = message;
+  }
+
+  if (input.type !== 'radio') {
+    input.setAttribute('aria-invalid', message ? 'true' : 'false');
+  }
+
+  return message === '';
+};
+
+const attachValidation = (form) => {
+  const fields = form.querySelectorAll('input[required], select[required]');
+  fields.forEach((field) => {
+    const eventName = field.type === 'radio' ? 'change' : 'input';
+    field.addEventListener(eventName, () => validateRequired(field));
+    field.addEventListener('blur', () => validateRequired(field));
+  });
+};
+
+const serializeForm = (form) => {
+  const data = new FormData(form);
+  const payload = {};
+  data.forEach((value, key) => {
+    if (payload[key]) {
+      if (Array.isArray(payload[key])) {
+        payload[key].push(value);
+      } else {
+        payload[key] = [payload[key], value];
+      }
+    } else {
+      payload[key] = value;
+    }
+  });
+  payload.form_name = form.id;
+  return payload;
+};
+
+const startButtonLoading = (button) => {
+  if (!button) return;
+  const loadingText = button.dataset.loadingText || 'Chargement…';
+  if (!button.dataset.originalLabel) {
+    const label = button.querySelector('.btn-label');
+    button.dataset.originalLabel = label ? label.textContent : button.textContent;
+  }
+  const label = button.querySelector('.btn-label');
+  if (label) {
+    label.textContent = loadingText;
+  } else {
+    button.textContent = loadingText;
+  }
+  button.disabled = true;
+  button.classList.add('is-loading');
+  button.setAttribute('aria-busy', 'true');
+};
+
+const stopButtonLoading = (button) => {
+  if (!button) return;
+  const original = button.dataset.originalLabel;
+  const label = button.querySelector('.btn-label');
+  if (original) {
+    if (label) {
+      label.textContent = original;
+    } else {
+      button.textContent = original;
+    }
+  }
+  button.disabled = false;
+  button.classList.remove('is-loading');
+  button.removeAttribute('aria-busy');
+  delete button.dataset.originalLabel;
+};
+
+const DEFAULT_SUCCESS_MESSAGE = '✔ Un conseiller vous rappelle sous 2&nbsp;h (9h–19h, lun–sam).';
+
+const handleSubmit = (event) => {
+  event.preventDefault();
+  const form = event.currentTarget;
+  const submitButton = form.querySelector('button[type="submit"]');
+  const requiredFields = form.querySelectorAll('input[required], select[required]');
+  let formIsValid = true;
+
+  requiredFields.forEach((field) => {
+    if (field.type === 'radio') {
+      const name = field.name;
+      const radios = form.querySelectorAll(`input[name="${name}"]`);
+      const checked = Array.from(radios).some((radio) => radio.checked);
+      const errorEl = form.querySelector(`[data-error-for="${name}"]`);
+      if (!checked) {
+        formIsValid = false;
+        if (errorEl) errorEl.textContent = 'Veuillez sélectionner une option.';
+      } else if (errorEl) {
+        errorEl.textContent = '';
+      }
+    } else if (!validateRequired(field)) {
+      if (formIsValid) {
+        field.focus();
+      }
+      formIsValid = false;
+    }
+  });
+
+  if (!formIsValid) {
+    showToast('Merci de vérifier les champs en rouge.', true);
+    return;
+  }
+
+  startButtonLoading(submitButton);
+
+  const payload = serializeForm(form);
+
+  if (form.id === 'tad-form' || form.id === 'devis-form') {
+    payload.recipient_email = 'caro.resanavettephoenix@gmail.com';
+    payload.manager_email = 'Phoenix.lts28@navettephoenix.fr';
+  }
+
+  fetch(appsScriptUrl, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(payload),
+  })
+    .then((response) => {
+      if (!response.ok && (response.status < 200 || response.status >= 400)) {
+        throw new Error(`Erreur réseau (${response.status})`);
+      }
+      return response.json().catch(() => ({}));
+    })
+    .then(() => {
+      form.reset();
+      const totalEl = form.querySelector('#tad-total');
+      if (totalEl) {
+        totalEl.textContent = '0 €';
+      }
+      openSuccessModal(DEFAULT_SUCCESS_MESSAGE);
+    })
+    .catch((error) => {
+      console.error(error);
+      showToast('Une erreur est survenue. Merci de réessayer dans quelques instants.', true);
+    })
+    .finally(() => {
+      stopButtonLoading(submitButton);
+    });
+};
+
+const tadForm = document.getElementById('tad-form');
+const devisForm = document.getElementById('devis-form');
+
+if (tadForm) {
+  attachValidation(tadForm);
+  tadForm.addEventListener('submit', handleSubmit);
+  const passengersSelect = document.getElementById('tad-passengers');
+  const totalEl = document.getElementById('tad-total');
+  const pricePerPassenger = 5;
+  if (passengersSelect && totalEl) {
+    const updateTotal = () => {
+      const passengers = Number(passengersSelect.value);
+      if (passengers > 0) {
+        const total = passengers * pricePerPassenger;
+        totalEl.textContent = `${total.toLocaleString('fr-FR')} €`;
+      } else {
+        totalEl.textContent = '0 €';
+      }
+    };
+    passengersSelect.addEventListener('change', updateTotal);
+    updateTotal();
+  }
+}
+
+if (devisForm) {
+  attachValidation(devisForm);
+  devisForm.addEventListener('submit', handleSubmit);
+}
+
+const dateTimeInputs = document.querySelectorAll('input[type="date"], input[type="time"]');
+dateTimeInputs.forEach((input) => {
+  input.addEventListener('keydown', (event) => {
+    const allowedKeys = ['Tab', 'Shift', 'ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown', 'Enter', 'Escape'];
+    if (!allowedKeys.includes(event.key)) {
+      event.preventDefault();
+    }
+  });
+  input.addEventListener('focus', () => {
+    if (typeof input.showPicker === 'function') {
+      input.showPicker();
+    }
+  });
+});
+
+// Comparateur de trajets
+const compareForm = document.getElementById('compare-form');
+const compareMapElement = document.getElementById('compare-map');
+const distanceEl = document.getElementById('result-distance');
+const shuttleEl = document.getElementById('result-shuttle');
+const carEl = document.getElementById('result-car');
+
+let compareMap;
+let routeLayer;
+let pickupMarker;
+let dropoffMarker;
+
+const initMap = () => {
+  if (!compareMapElement || typeof L === 'undefined') return;
+  compareMap = L.map(compareMapElement, {
+    center: [48.32, 0.82],
+    zoom: 9,
+    zoomControl: false,
+  });
+
+  L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+    maxZoom: 19,
+    attribution: '&copy; <a href="https://www.openstreetmap.org/">OpenStreetMap</a> contributors',
+  }).addTo(compareMap);
+
+  L.control.zoom({ position: 'bottomright' }).addTo(compareMap);
+};
+
+const geocodeAddress = async (query) => {
+  const url = new URL('https://nominatim.openstreetmap.org/search');
+  url.searchParams.set('format', 'json');
+  url.searchParams.set('limit', '1');
+  url.searchParams.set('addressdetails', '0');
+  url.searchParams.set('countrycodes', 'fr');
+  url.searchParams.set('q', `${query}, France`);
+
+  const response = await fetch(url.toString(), {
+    headers: {
+      'Accept-Language': 'fr',
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error('Impossible de géocoder cette adresse.');
+  }
+
+  const results = await response.json();
+  if (!Array.isArray(results) || results.length === 0) {
+    throw new Error('Adresse introuvable. Merci de préciser la commune.');
+  }
+
+  const [result] = results;
+  return {
+    lat: Number(result.lat),
+    lon: Number(result.lon),
+    label: result.display_name,
+  };
+};
+
+const fetchRoute = async (start, end) => {
+  const url = `https://router.project-osrm.org/route/v1/driving/${start.lon},${start.lat};${end.lon},${end.lat}?overview=full&geometries=geojson`;
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error('Impossible de calculer l’itinéraire.');
+  }
+  const data = await response.json();
+  if (!data.routes || !data.routes.length) {
+    throw new Error('Aucun itinéraire trouvé.');
+  }
+  return data.routes[0];
+};
+
+const formatDistance = (meters) => {
+  const km = meters / 1000;
+  return `${km.toLocaleString('fr-FR', { maximumFractionDigits: 1 })} km`;
+};
+
+const formatDuration = (minutes) => {
+  const rounded = Math.round(minutes);
+  const hours = Math.floor(rounded / 60);
+  const mins = rounded % 60;
+  if (hours > 0) {
+    return `${hours} h ${mins.toString().padStart(2, '0')} min`;
+  }
+  return `${mins} min`;
+};
+
+const updateMap = (route, start, end) => {
+  if (!compareMap) return;
+
+  if (routeLayer) {
+    routeLayer.remove();
+  }
+  if (pickupMarker) {
+    pickupMarker.remove();
+  }
+  if (dropoffMarker) {
+    dropoffMarker.remove();
+  }
+
+  routeLayer = L.geoJSON(route.geometry, {
+    style: {
+      color: '#ff8c24',
+      weight: 5,
+      opacity: 0.85,
+    },
+  }).addTo(compareMap);
+
+  pickupMarker = L.marker([start.lat, start.lon], {
+    title: 'Prise en charge',
+  }).addTo(compareMap);
+
+  dropoffMarker = L.marker([end.lat, end.lon], {
+    title: 'Dépose',
+  }).addTo(compareMap);
+
+  const bounds = routeLayer.getBounds();
+  if (bounds.isValid()) {
+    compareMap.fitBounds(bounds, { padding: [32, 32] });
+  }
+};
+
+const handleCompareSubmit = async (event) => {
+  event.preventDefault();
+  if (!compareForm) return;
+
+  const submitButton = compareForm.querySelector('button[type="submit"]');
+  const requiredFields = compareForm.querySelectorAll('input[required]');
+  let formIsValid = true;
+
+  requiredFields.forEach((field) => {
+    if (!validateRequired(field)) {
+      if (formIsValid) {
+        field.focus();
+      }
+      formIsValid = false;
+    }
+  });
+
+  if (!formIsValid) {
+    showToast('Merci de vérifier les champs en rouge.', true);
+    return;
+  }
+
+  startButtonLoading(submitButton);
+
+  const pickupField = compareForm.elements.namedItem('compare_pickup');
+  const dropoffField = compareForm.elements.namedItem('compare_dropoff');
+
+  if (!pickupField || !dropoffField) {
+    stopButtonLoading(submitButton);
+    showToast('Champs de formulaire introuvables.', true);
+    return;
+  }
+
+  try {
+    const [pickup, dropoff] = await Promise.all([
+      geocodeAddress(pickupField.value),
+      geocodeAddress(dropoffField.value),
+    ]);
+
+    const route = await fetchRoute(pickup, dropoff);
+
+    const carDurationMinutes = route.duration / 60;
+    const shuttleDurationMinutes = carDurationMinutes + 10; // marge opérationnelle
+
+    if (distanceEl) {
+      distanceEl.textContent = formatDistance(route.distance);
+    }
+    if (carEl) {
+      carEl.textContent = formatDuration(carDurationMinutes);
+    }
+    if (shuttleEl) {
+      shuttleEl.textContent = formatDuration(shuttleDurationMinutes);
+    }
+
+    updateMap(route, pickup, dropoff);
+  } catch (error) {
+    console.error(error);
+    showToast(error.message || 'Impossible de calculer ce trajet pour le moment.', true);
+  } finally {
+    stopButtonLoading(submitButton);
+  }
+};
+
+if (compareMapElement) {
+  initMap();
+}
+
+if (compareForm) {
+  attachValidation(compareForm);
+  compareForm.addEventListener('submit', handleCompareSubmit);
+}

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -1,0 +1,642 @@
+:root {
+  --orange-start: #ff7a18;
+  --orange-end: #ffb347;
+  --orange-solid: #ff8c24;
+  --text-dark: #222222;
+  --text-muted: #555555;
+  --background: #ffffff;
+  --background-alt: #fff7f0;
+  --border-color: rgba(0, 0, 0, 0.08);
+  --success: #24a148;
+  --error: #d93025;
+  --shadow: 0 12px 30px rgba(0, 0, 0, 0.1);
+  --radius-large: 24px;
+  --radius-medium: 16px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: "Poppins", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  color: var(--text-dark);
+  background: var(--background);
+  line-height: 1.6;
+}
+
+a {
+  color: var(--orange-solid);
+  text-decoration: none;
+}
+
+a:hover,
+a:focus {
+  text-decoration: underline;
+}
+
+.container {
+  width: min(1080px, 92vw);
+  margin: 0 auto;
+}
+
+.site-header {
+  background: linear-gradient(135deg, var(--orange-start), var(--orange-end));
+  color: #fff;
+  padding: 1.5rem 0;
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  box-shadow: 0 8px 20px rgba(255, 138, 50, 0.35);
+}
+
+.branding {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.logo {
+  width: 64px;
+  height: auto;
+}
+
+.app-name {
+  font-size: 1.35rem;
+  font-weight: 600;
+  margin: 0;
+}
+
+.app-tagline {
+  margin: 0;
+  font-size: 0.9rem;
+  opacity: 0.9;
+}
+
+.main-nav {
+  margin-top: 1rem;
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.main-nav a {
+  color: #fff;
+  font-weight: 500;
+  padding: 0.4rem 0.75rem;
+  border-radius: 999px;
+  transition: background 0.3s ease, transform 0.3s ease;
+}
+
+.main-nav a:hover,
+.main-nav a:focus {
+  background: rgba(255, 255, 255, 0.2);
+  transform: translateY(-1px);
+}
+
+.hero {
+  padding: clamp(3rem, 8vw, 5.5rem) 0;
+  background: linear-gradient(180deg, rgba(255, 138, 50, 0.12), rgba(255, 255, 255, 0));
+}
+
+.hero-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 2.5rem;
+  align-items: center;
+}
+
+.hero h1 {
+  font-size: clamp(2rem, 4vw, 2.8rem);
+  margin-bottom: 1rem;
+}
+
+.hero p {
+  margin-bottom: 1.5rem;
+  color: var(--text-muted);
+}
+
+.hero-card {
+  border-radius: var(--radius-large);
+  overflow: hidden;
+  box-shadow: var(--shadow);
+  background: #fff;
+  min-height: 320px;
+}
+
+.hero-card iframe {
+  border: 0;
+  width: 100%;
+  height: 100%;
+  min-height: 320px;
+}
+
+.btn {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  background: var(--orange-solid);
+  color: #fff;
+  padding: 0.85rem 1.8rem;
+  border-radius: 16px;
+  font-weight: 600;
+  box-shadow: 0 12px 20px rgba(255, 138, 50, 0.3);
+  transition: transform 0.2s ease, box-shadow 0.2s ease, opacity 0.2s ease;
+  border: none;
+  cursor: pointer;
+}
+
+.btn:hover,
+.btn:focus {
+  transform: translateY(-2px);
+  box-shadow: 0 16px 28px rgba(255, 138, 50, 0.35);
+}
+
+.btn:disabled {
+  cursor: not-allowed;
+  opacity: 0.65;
+  transform: none;
+}
+
+.btn .btn-label {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.btn.is-loading .btn-label {
+  opacity: 0;
+}
+
+.btn.is-loading::after {
+  content: "";
+  position: absolute;
+  width: 1.25rem;
+  height: 1.25rem;
+  border-radius: 50%;
+  border: 3px solid rgba(255, 255, 255, 0.45);
+  border-top-color: #fff;
+  animation: spin 0.8s linear infinite;
+}
+
+.btn-outline {
+  background: rgba(255, 255, 255, 0.92);
+  color: var(--orange-solid);
+  border: 2px solid var(--orange-solid);
+  box-shadow: none;
+}
+
+.btn-full {
+  width: 100%;
+  margin-top: 1rem;
+}
+
+.section {
+  padding: clamp(3rem, 7vw, 4.5rem) 0;
+}
+
+.section-alt {
+  background: var(--background-alt);
+}
+
+.section h2 {
+  font-size: clamp(1.8rem, 3vw, 2.4rem);
+  margin-bottom: 1.5rem;
+  text-align: center;
+}
+
+.section > .container > p {
+  text-align: center;
+  margin-bottom: 2rem;
+  color: var(--text-muted);
+}
+
+.grid {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.grid-3 {
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.card {
+  background: #fff;
+  border-radius: var(--radius-medium);
+  padding: 1.75rem;
+  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.card h3 {
+  margin: 0;
+  font-size: 1.15rem;
+}
+
+.action-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1rem;
+}
+
+.action-card {
+  display: grid;
+  grid-template-columns: auto;
+  justify-items: center;
+  text-align: center;
+  padding: 1.5rem 1rem;
+  border-radius: var(--radius-medium);
+  background: #fff;
+  color: var(--text-dark);
+  box-shadow: 0 10px 24px rgba(255, 138, 50, 0.18);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.action-card:hover,
+.action-card:focus {
+  transform: translateY(-3px);
+  box-shadow: 0 16px 28px rgba(255, 138, 50, 0.24);
+  text-decoration: none;
+}
+
+.action-icon {
+  width: 56px;
+  height: 56px;
+  border-radius: 18px;
+  background: linear-gradient(135deg, rgba(255, 138, 50, 0.15), rgba(255, 138, 50, 0.3));
+  color: var(--orange-solid);
+  display: grid;
+  place-items: center;
+  margin-bottom: 1rem;
+}
+
+.action-label {
+  font-weight: 600;
+  margin: 0;
+}
+
+.form {
+  background: #fff;
+  border-radius: var(--radius-large);
+  padding: clamp(2rem, 5vw, 3rem);
+  box-shadow: var(--shadow);
+  display: grid;
+  gap: 1.25rem;
+}
+
+.form-field {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+}
+
+.form-field input,
+.form-field select {
+  padding: 1rem 1rem 0.9rem;
+  border-radius: 14px;
+  border: 1px solid var(--border-color);
+  font-size: 1rem;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+  background: #fff;
+}
+
+.form-field input:focus,
+.form-field select:focus {
+  outline: none;
+  border-color: var(--orange-solid);
+  box-shadow: 0 0 0 4px rgba(255, 138, 50, 0.25);
+}
+
+.form-field label {
+  position: absolute;
+  left: 1rem;
+  top: 1rem;
+  font-size: 0.95rem;
+  color: var(--text-muted);
+  pointer-events: none;
+  transform-origin: top left;
+  transition: transform 0.2s ease, color 0.2s ease, top 0.2s ease;
+  background: #fff;
+  padding: 0 0.35rem;
+}
+
+.form-field input:focus + label,
+.form-field input:not(:placeholder-shown) + label {
+  top: 0.2rem;
+  transform: scale(0.82) translateY(-10%);
+  color: var(--orange-solid);
+}
+
+.select-field {
+  gap: 0.5rem;
+}
+
+.select-field label {
+  position: static;
+  transform: none;
+  padding: 0;
+  font-weight: 600;
+  color: var(--text-dark);
+}
+
+.select-field input,
+.select-field select {
+  padding: 0.9rem 1rem;
+}
+
+.form-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 1rem;
+}
+
+.form-footnote {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 0.9rem;
+  text-align: center;
+}
+
+.total {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 1.15rem;
+  background: rgba(255, 138, 50, 0.1);
+  padding: 0.75rem 1rem;
+  border-radius: 12px;
+  font-weight: 600;
+}
+
+.segmented {
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-medium);
+  padding: 1rem 1.25rem;
+  background: rgba(255, 255, 255, 0.9);
+}
+
+.segment-group {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 0.75rem;
+}
+
+.segment {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 12px;
+  border: 1px solid var(--border-color);
+  padding: 0.8rem 1rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: border-color 0.2s ease, background 0.2s ease, color 0.2s ease;
+}
+
+.segment input {
+  position: absolute;
+  opacity: 0;
+}
+
+.segment span {
+  pointer-events: none;
+}
+
+.segment input:checked + span {
+  background: var(--orange-solid);
+  color: #fff;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+}
+
+.segment input:focus + span {
+  box-shadow: 0 0 0 4px rgba(255, 138, 50, 0.25);
+}
+
+.error {
+  color: var(--error);
+  font-size: 0.85rem;
+  min-height: 1em;
+  margin: 0.35rem 0 0;
+}
+
+.form-field input[aria-invalid="true"],
+.form-field select[aria-invalid="true"] {
+  border-color: var(--error);
+  box-shadow: 0 0 0 3px rgba(217, 48, 37, 0.18);
+}
+
+.toast {
+  position: fixed;
+  bottom: 2rem;
+  right: 2rem;
+  background: var(--orange-solid);
+  color: #fff;
+  padding: 1rem 1.5rem;
+  border-radius: 16px;
+  box-shadow: var(--shadow);
+  max-width: 320px;
+  font-weight: 500;
+  z-index: 999;
+}
+
+.toast.error {
+  background: var(--error);
+}
+
+.modal-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.4);
+  z-index: 998;
+}
+
+.modal {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 999;
+}
+
+.modal[hidden],
+.modal-backdrop[hidden] {
+  display: none;
+}
+
+.modal-content {
+  background: #fff;
+  border-radius: var(--radius-large);
+  padding: 2.5rem 2rem;
+  width: min(420px, 90vw);
+  text-align: center;
+  box-shadow: 0 18px 40px rgba(0, 0, 0, 0.18);
+  display: grid;
+  gap: 1.5rem;
+}
+
+.modal-content h3 {
+  margin: 0;
+  font-size: 1.6rem;
+}
+
+.modal-content p {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 1rem;
+}
+
+.compare-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 2rem;
+  align-items: start;
+}
+
+.map-panel {
+  display: grid;
+  gap: 1.25rem;
+}
+
+#compare-map {
+  width: 100%;
+  min-height: 320px;
+  border-radius: var(--radius-large);
+  overflow: hidden;
+  box-shadow: var(--shadow);
+}
+
+.compare-results {
+  display: grid;
+  gap: 0.75rem;
+  background: #fff;
+  padding: 1.25rem;
+  border-radius: var(--radius-medium);
+  box-shadow: 0 8px 18px rgba(0, 0, 0, 0.08);
+}
+
+.compare-results div {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.result-label {
+  color: var(--text-muted);
+  font-size: 0.95rem;
+}
+
+.contact-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 2rem;
+  align-items: start;
+}
+
+.contact-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.contact-card {
+  background: #fff;
+  border-radius: var(--radius-medium);
+  padding: 1.75rem;
+  box-shadow: var(--shadow);
+  display: grid;
+  gap: 1rem;
+}
+
+.site-footer {
+  padding: 1.5rem 0;
+  background: #111111;
+  color: #f5f5f5;
+}
+
+.footer-grid {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 1rem;
+  align-items: center;
+}
+
+.footer-grid nav a {
+  color: #f5f5f5;
+  margin-left: 1rem;
+}
+
+.leaflet-container {
+  width: 100%;
+  height: 100%;
+}
+
+@media (max-width: 900px) {
+  .main-nav {
+    justify-content: center;
+  }
+
+  .hero-card {
+    order: -1;
+  }
+
+  .site-header {
+    position: static;
+  }
+
+  .action-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 600px) {
+  .action-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 0.75rem;
+  }
+
+  .action-card {
+    padding: 1.25rem 0.75rem;
+  }
+
+  .btn {
+    padding: 0.75rem 1.4rem;
+  }
+
+  #compare-map {
+    min-height: 260px;
+  }
+
+  .toast {
+    left: 50%;
+    right: auto;
+    transform: translateX(-50%);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(1turn);
+  }
+}

--- a/index.html
+++ b/index.html
@@ -1,0 +1,438 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Navette Phoenix – Transport à la Demande</title>
+  <meta
+    name="description"
+    content="Réservez votre navette à la demande dans les communautés Terre de Perche et Forêt du Perche. Tarif fixe de 5 € par personne, 4 places maximum."
+  />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link
+    href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&display=swap"
+    rel="stylesheet"
+  />
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha512-XQoYMqMTK8LvdxXYG3nZ448hOEQiglfqkJs1NOQV44cWnUrBc8PkAOcXy20w0vlaXaVUearIOBhiXZ5V3ynxwA==" crossorigin="" />
+  <link rel="stylesheet" href="assets/styles.css" />
+  <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha512-v7bU1Cq7G8zDeihh5Z8SGvtQvECOH14R/2uOeGjn5ER5YjZL+QkNo4fU6CWPG6lzQIsLMgIp2GDa3hWkC5xg8g==" crossorigin="" defer></script>
+</head>
+<body>
+  <header class="site-header">
+    <div class="container">
+      <div class="branding">
+        <img
+          src="https://www.navettephoenix.fr/wp-content/uploads/2023/07/cropped-logo-navette-phoenix-2.png"
+          alt="Logo Navette Phoenix"
+          class="logo"
+        />
+        <div>
+          <p class="app-name">Navette Phoenix</p>
+          <p class="app-tagline">Transport à la Demande – Communautés Terre &amp; Forêt du Perche</p>
+        </div>
+      </div>
+      <nav class="main-nav" aria-label="Navigation principale">
+        <a href="#services">Services</a>
+        <a href="#reservation">Réservation TAD</a>
+        <a href="#comparateur">Comparateur</a>
+        <a href="#devis">Devis hors secteur</a>
+        <a href="#contact">Contacts</a>
+        <a href="privacy.html">Politique de confidentialité</a>
+      </nav>
+    </div>
+  </header>
+
+  <main>
+    <section class="hero">
+      <div class="container hero-grid">
+        <div>
+          <h1>Votre navette locale, rapide et fiable</h1>
+          <p>
+            Réservez votre trajet dans les communautés de communes
+            <strong>Terre de Perche</strong> et <strong>Forêt du Perche</strong>.
+            Tarif unique de <strong>5 € par personne</strong>, jusqu’à 4 places par navette.
+          </p>
+          <div class="hero-cta">
+            <a class="btn" href="#reservation">Réserver maintenant</a>
+            <a class="btn btn-outline" href="#devis">Demander un devis</a>
+          </div>
+        </div>
+        <div class="hero-card" aria-label="Carte des zones desservies">
+          <iframe
+            title="Carte des communautés Terre et Forêt du Perche"
+            src="https://www.google.com/maps/d/embed?mid=1YHSYqZgyE3lPmMVojWa3FzaAmZ-Ci_E&ehbc=2E312F"
+            loading="lazy"
+          ></iframe>
+        </div>
+      </div>
+    </section>
+
+    <section class="section section-alt" id="actions">
+      <div class="container">
+        <h2>Accès rapide</h2>
+        <div class="action-grid" role="list">
+          <a class="action-card" href="#reservation" role="listitem">
+            <div class="action-icon" aria-hidden="true">
+              <svg width="32" height="32" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                <path
+                  d="M5 16l3.2-8h9.4a1.4 1.4 0 011.35 1.74l-1.4 5.6A1.4 1.4 0 0116.2 16H5z"
+                  stroke="currentColor"
+                  stroke-width="1.6"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                />
+                <circle cx="7.5" cy="19" r="1.5" fill="currentColor" />
+                <circle cx="16.5" cy="19" r="1.5" fill="currentColor" />
+              </svg>
+            </div>
+            <p class="action-label">Réserver un trajet TAD</p>
+          </a>
+          <a class="action-card" href="#devis" role="listitem">
+            <div class="action-icon" aria-hidden="true">
+              <svg width="32" height="32" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                <path
+                  d="M6 3h9l3 3v13a2 2 0 01-2 2H6a2 2 0 01-2-2V5a2 2 0 012-2z"
+                  stroke="currentColor"
+                  stroke-width="1.6"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                />
+                <path d="M9 13h6" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" />
+                <path d="M9 9h6" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" />
+              </svg>
+            </div>
+            <p class="action-label">Demander un devis</p>
+          </a>
+          <a class="action-card" href="#comparateur" role="listitem">
+            <div class="action-icon" aria-hidden="true">
+              <svg width="32" height="32" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                <path
+                  d="M4 17h16M4 7h16M10 3l-2 4h4l-2 4"
+                  stroke="currentColor"
+                  stroke-width="1.6"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                />
+                <circle cx="7" cy="17" r="1.5" fill="currentColor" />
+                <circle cx="17" cy="7" r="1.5" fill="currentColor" />
+              </svg>
+            </div>
+            <p class="action-label">Comparer un trajet</p>
+          </a>
+          <a class="action-card" href="#contact" role="listitem">
+            <div class="action-icon" aria-hidden="true">
+              <svg width="32" height="32" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                <path
+                  d="M4 5a2 2 0 012-2h1.3a1 1 0 01.93.66l1.24 3.71a1 1 0 01-.43 1.17l-1.66 1.1a12.05 12.05 0 006.6 6.6l1.1-1.66a1 1 0 011.17-.43l3.71 1.24a1 1 0 01.66.93V18a2 2 0 01-2 2h-1C9.82 20 4 14.18 4 7V5z"
+                  stroke="currentColor"
+                  stroke-width="1.6"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                />
+              </svg>
+            </div>
+            <p class="action-label">Contacts &amp; aide</p>
+          </a>
+        </div>
+      </div>
+    </section>
+
+    <section id="services" class="section">
+      <div class="container">
+        <h2>Pourquoi choisir Navette Phoenix&nbsp;?</h2>
+        <div class="grid grid-3">
+          <article class="card">
+            <h3>Couverture locale optimale</h3>
+            <p>
+              Prise en charge sur l’ensemble des villages des communautés
+              <strong>Terre de Perche</strong> et <strong>Forêt du Perche</strong>.
+            </p>
+          </article>
+          <article class="card">
+            <h3>Tarif clair</h3>
+            <p>
+              <strong>5 € par personne</strong>, jusqu’à 4 passagers. Aucun frais caché&nbsp;: calculez instantanément le montant de
+              votre trajet TAD.
+            </p>
+          </article>
+          <article class="card">
+            <h3>Réservation simplifiée</h3>
+            <p>Formulaires rapides, validations automatiques et envoi direct vers notre équipe sans quitter l’application.</p>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <section id="reservation" class="section section-alt">
+      <div class="container">
+        <h2>Réservation Transport à la Demande (TAD)</h2>
+        <p>Remplissez les informations ci-dessous. Un conseiller vous rappelle sous 2&nbsp;h (9h–19h, lun–sam).</p>
+        <form id="tad-form" class="form" novalidate>
+          <div class="form-field">
+            <input type="text" id="tad-firstname" name="firstname" placeholder=" " required autocomplete="given-name" />
+            <label for="tad-firstname">Prénom *</label>
+            <p class="error" data-error-for="tad-firstname"></p>
+          </div>
+          <div class="form-field">
+            <input type="text" id="tad-lastname" name="lastname" placeholder=" " required autocomplete="family-name" />
+            <label for="tad-lastname">Nom *</label>
+            <p class="error" data-error-for="tad-lastname"></p>
+          </div>
+          <div class="form-field">
+            <input
+              type="tel"
+              id="tad-phone"
+              name="phone"
+              placeholder=" "
+              required
+              inputmode="tel"
+              pattern="^(\\+33|0)[1-9](?:[ .-]?\\d{2}){4}$"
+            />
+            <label for="tad-phone">Téléphone *</label>
+            <p class="error" data-error-for="tad-phone"></p>
+          </div>
+          <div class="form-field">
+            <input type="text" id="tad-pickup" name="pickup" placeholder=" " required autocomplete="address-line1" />
+            <label for="tad-pickup">Adresse de prise en charge *</label>
+            <p class="error" data-error-for="tad-pickup"></p>
+          </div>
+          <div class="form-field">
+            <input type="text" id="tad-dropoff" name="dropoff" placeholder=" " required autocomplete="address-line2" />
+            <label for="tad-dropoff">Adresse de dépose *</label>
+            <p class="error" data-error-for="tad-dropoff"></p>
+          </div>
+          <div class="form-grid">
+            <div class="form-field select-field">
+              <label for="tad-date">Date *</label>
+              <input type="date" id="tad-date" name="date" required />
+              <p class="error" data-error-for="tad-date"></p>
+            </div>
+            <div class="form-field select-field">
+              <label for="tad-time">Heure *</label>
+              <input type="time" id="tad-time" name="time" required />
+              <p class="error" data-error-for="tad-time"></p>
+            </div>
+            <div class="form-field select-field">
+              <label for="tad-passengers">Nombre de passagers *</label>
+              <select id="tad-passengers" name="passengers" required>
+                <option value="" disabled selected>Choisissez</option>
+                <option value="1">1</option>
+                <option value="2">2</option>
+                <option value="3">3</option>
+                <option value="4">4</option>
+              </select>
+              <p class="error" data-error-for="tad-passengers"></p>
+            </div>
+          </div>
+          <div class="total" aria-live="polite">
+            <span>Total estimé :</span>
+            <strong id="tad-total">0 €</strong>
+          </div>
+          <button type="submit" class="btn btn-full" data-loading-text="Envoi en cours…">
+            <span class="btn-label">Envoyer la réservation</span>
+          </button>
+          <p class="form-footnote">✔ Un conseiller vous rappelle sous 2&nbsp;h (9h–19h, lun–sam).</p>
+        </form>
+      </div>
+    </section>
+
+    <section id="comparateur" class="section">
+      <div class="container">
+        <h2>Comparer votre temps de trajet</h2>
+        <p>
+          Saisissez votre point de départ et d’arrivée pour estimer la durée en navette Navette Phoenix et en voiture personnelle.
+          Les temps sont donnés à titre indicatif.
+        </p>
+        <div class="compare-grid">
+          <form id="compare-form" class="form" novalidate>
+            <div class="form-field">
+              <input type="text" id="compare-pickup" name="compare_pickup" placeholder=" " required />
+              <label for="compare-pickup">Adresse de prise en charge *</label>
+              <p class="error" data-error-for="compare-pickup"></p>
+            </div>
+            <div class="form-field">
+              <input type="text" id="compare-dropoff" name="compare_dropoff" placeholder=" " required />
+              <label for="compare-dropoff">Adresse de dépose *</label>
+              <p class="error" data-error-for="compare-dropoff"></p>
+            </div>
+            <button type="submit" class="btn btn-full" data-loading-text="Calcul en cours…">
+              <span class="btn-label">Calculer le trajet</span>
+            </button>
+            <p class="form-footnote">Temps indicatifs basés sur des données routières ouvertes (OSM/OSRM).</p>
+          </form>
+          <div class="map-panel">
+            <div id="compare-map" aria-label="Carte de comparaison des trajets"></div>
+            <div class="compare-results" aria-live="polite">
+              <div>
+                <span class="result-label">Distance totale</span>
+                <strong id="result-distance">—</strong>
+              </div>
+              <div>
+                <span class="result-label">Temps estimé navette</span>
+                <strong id="result-shuttle">—</strong>
+              </div>
+              <div>
+                <span class="result-label">Temps estimé voiture</span>
+                <strong id="result-car">—</strong>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section id="devis" class="section">
+      <div class="container">
+        <h2>Devis hors secteur — Gare, Aéroport, Paris, toute la France</h2>
+        <p>Pour vos trajets longue distance, indiquez-nous vos besoins. Nous vous recontactons rapidement avec une proposition personnalisée.</p>
+        <form id="devis-form" class="form" novalidate>
+          <div class="form-field">
+            <input type="text" id="quote-name" name="name" placeholder=" " required autocomplete="name" />
+            <label for="quote-name">Nom et prénom *</label>
+            <p class="error" data-error-for="quote-name"></p>
+          </div>
+          <div class="form-field">
+            <input
+              type="tel"
+              id="quote-phone"
+              name="phone"
+              placeholder=" "
+              required
+              inputmode="tel"
+              pattern="^(\\+33|0)[1-9](?:[ .-]?\\d{2}){4}$"
+            />
+            <label for="quote-phone">Téléphone *</label>
+            <p class="error" data-error-for="quote-phone"></p>
+          </div>
+          <div class="form-field">
+            <input type="email" id="quote-email" name="email" placeholder=" " required autocomplete="email" />
+            <label for="quote-email">E-mail *</label>
+            <p class="error" data-error-for="quote-email"></p>
+          </div>
+          <div class="form-field">
+            <input type="text" id="quote-pickup" name="pickup" placeholder=" " required />
+            <label for="quote-pickup">Adresse de prise en charge *</label>
+            <p class="error" data-error-for="quote-pickup"></p>
+          </div>
+          <div class="form-field">
+            <input type="text" id="quote-dropoff" name="dropoff" placeholder=" " required />
+            <label for="quote-dropoff">Adresse de dépose *</label>
+            <p class="error" data-error-for="quote-dropoff"></p>
+          </div>
+          <div class="form-grid">
+            <div class="form-field select-field">
+              <label for="quote-date">Date *</label>
+              <input type="date" id="quote-date" name="date" required />
+              <p class="error" data-error-for="quote-date"></p>
+            </div>
+            <div class="form-field select-field">
+              <label for="quote-time">Heure *</label>
+              <input type="time" id="quote-time" name="time" required />
+              <p class="error" data-error-for="quote-time"></p>
+            </div>
+          </div>
+          <fieldset class="segmented">
+            <legend>Type de trajet *</legend>
+            <div class="segment-group" role="radiogroup" aria-required="true">
+              <label class="segment">
+                <input type="radio" name="trip_type" value="Gare" required />
+                <span>Gare</span>
+              </label>
+              <label class="segment">
+                <input type="radio" name="trip_type" value="Aéroport" />
+                <span>Aéroport</span>
+              </label>
+              <label class="segment">
+                <input type="radio" name="trip_type" value="Paris" />
+                <span>Paris</span>
+              </label>
+              <label class="segment">
+                <input type="radio" name="trip_type" value="Toute la France" />
+                <span>Toute la France</span>
+              </label>
+            </div>
+            <p class="error" data-error-for="trip_type"></p>
+          </fieldset>
+          <button type="submit" class="btn btn-full" data-loading-text="Envoi en cours…">
+            <span class="btn-label">Demander un devis</span>
+          </button>
+          <p class="form-footnote">✔ Un conseiller vous rappelle sous 2&nbsp;h (9h–19h, lun–sam).</p>
+        </form>
+      </div>
+    </section>
+
+    <section class="section section-alt" id="engagements">
+      <div class="container grid grid-3">
+        <article class="card">
+          <h3>Suivi personnalisé</h3>
+          <p>Notifications SMS ou téléphone selon votre préférence pour confirmer et rappeler vos trajets.</p>
+        </article>
+        <article class="card">
+          <h3>Accessibilité</h3>
+          <p>Formulaires accessibles, contraste élevé et optimisés pour tous les smartphones Android modernes.</p>
+        </article>
+        <article class="card">
+          <h3>Réactivité</h3>
+          <p>Équipe locale disponible du lundi au samedi, 9h–19h, pour vos demandes et réclamations.</p>
+        </article>
+      </div>
+    </section>
+
+    <section id="contact" class="section">
+      <div class="container contact-grid">
+        <div>
+          <h2>Contacts directs</h2>
+          <ul class="contact-list">
+            <li><strong>Téléphone réservation :</strong> <a href="tel:+33652758286">06 52 75 82 86</a></li>
+            <li><strong>Téléphone information :</strong> <a href="tel:+33685704336">06 85 70 43 36</a></li>
+            <li><strong>E-mail réservation :</strong> <a href="mailto:caro.resanavettephoenix@gmail.com">caro.resanavettephoenix@gmail.com</a></li>
+            <li>
+              <strong>Renseignement &amp; réclamation :</strong>
+              <a href="mailto:Phoenix.lts28@navettephoenix.fr">Phoenix.lts28@navettephoenix.fr</a>
+            </li>
+          </ul>
+        </div>
+        <div class="contact-card">
+          <h3>Version de l’application</h3>
+          <p>Version actuelle : <strong>1.0.0</strong> (Code version Play Store&nbsp;: <strong>17</strong>).</p>
+          <p>Compatibilité&nbsp;: Android 7.0 et versions ultérieures.</p>
+          <a class="btn btn-outline" href="https://www.navettephoenix.fr/" target="_blank" rel="noopener">Découvrir notre site officiel</a>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <div class="container footer-grid">
+      <p>&copy; <span id="current-year"></span> Navette Phoenix. Tous droits réservés.</p>
+      <nav aria-label="Liens de pied de page">
+        <a href="privacy.html">Politique de confidentialité</a>
+        <a href="#reservation">Réserver un trajet</a>
+      </nav>
+    </div>
+  </footer>
+
+  <div class="toast" role="status" aria-live="polite" hidden></div>
+  <div class="modal-backdrop" hidden></div>
+  <div
+    class="modal"
+    id="success-modal"
+    role="alertdialog"
+    aria-modal="true"
+    aria-labelledby="success-title"
+    hidden
+    tabindex="-1"
+  >
+    <div class="modal-content">
+      <h3 id="success-title">Demande envoyée</h3>
+      <p id="success-message">✔ Un conseiller vous rappelle sous 2&nbsp;h (9h–19h, lun–sam).</p>
+      <button type="button" class="btn btn-full" data-close-modal>
+        <span class="btn-label">Fermer</span>
+      </button>
+    </div>
+  </div>
+
+  <script src="assets/script.js" defer></script>
+</body>
+</html>

--- a/privacy.html
+++ b/privacy.html
@@ -1,0 +1,130 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Politique de confidentialité – Navette Phoenix</title>
+  <meta name="description" content="Politique de confidentialité de l’application Navette Phoenix – version code 17." />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="assets/styles.css" />
+  <style>
+    body { background: #fff; }
+    .privacy { padding: clamp(3rem, 7vw, 4.5rem) 0; }
+    .privacy h1 { text-align: center; font-size: clamp(2rem, 4vw, 2.8rem); }
+    .privacy p, .privacy li { color: var(--text-muted); }
+    .privacy section { margin-bottom: 2rem; background: #fff; padding: 2rem; border-radius: 18px; box-shadow: 0 10px 30px rgba(0,0,0,0.08); }
+    .privacy h2 { font-size: 1.4rem; margin-bottom: 1rem; color: var(--text-dark); }
+    .privacy ul { margin: 0; padding-left: 1.2rem; }
+    .privacy small { display: block; margin-top: 2rem; text-align: center; color: var(--text-muted); }
+    .back-link { display: inline-flex; align-items: center; gap: 0.5rem; margin-bottom: 1.5rem; color: var(--orange-solid); font-weight: 600; }
+  </style>
+</head>
+<body>
+  <header class="site-header">
+    <div class="container">
+      <div class="branding">
+        <a href="index.html" class="back-link">&larr; Retour à l’accueil</a>
+        <div>
+          <p class="app-name">Navette Phoenix</p>
+          <p class="app-tagline">Politique de confidentialité</p>
+        </div>
+      </div>
+    </div>
+  </header>
+
+  <main class="privacy">
+    <div class="container">
+      <h1>Politique de confidentialité</h1>
+      <p style="text-align:center;">Application mobile Navette Phoenix – Version 1.0.0 (code version Play Store&nbsp;: 17). Dernière mise à jour&nbsp;: <span id="privacy-date"></span>.</p>
+
+      <section>
+        <h2>1. Responsable du traitement</h2>
+        <p>Le traitement des données est opéré par Navette Phoenix, service de transport à la demande pour les communautés de communes Terre de Perche et Forêt du Perche.</p>
+        <p>Contact principal : <a href="mailto:caro.resanavettephoenix@gmail.com">caro.resanavettephoenix@gmail.com</a>.</p>
+      </section>
+
+      <section>
+        <h2>2. Données collectées</h2>
+        <ul>
+          <li>Données d’identification&nbsp;: prénom, nom.</li>
+          <li>Coordonnées&nbsp;: numéro de téléphone, adresse e-mail (pour les demandes de devis).</li>
+          <li>Informations de trajet&nbsp;: adresses de prise en charge et de dépose, date, heure, nombre de passagers, type de trajet.</li>
+        </ul>
+        <p>Nous ne collectons aucune donnée sensible ni donnée de localisation en temps réel.</p>
+      </section>
+
+      <section>
+        <h2>3. Finalités</h2>
+        <p>Les données collectées servent exclusivement à :</p>
+        <ul>
+          <li>Réserver un transport à la demande dans les communautés desservies.</li>
+          <li>Établir un devis pour les trajets hors secteur (gares, aéroports, Paris, reste de la France).</li>
+          <li>Contacter l’utilisateur pour confirmer, modifier ou suivre sa demande.</li>
+        </ul>
+      </section>
+
+      <section>
+        <h2>4. Base juridique</h2>
+        <p>Le traitement repose sur l’exécution d’un service demandé par l’utilisateur. Les données sont fournies volontairement lors de la réservation ou de la demande de devis.</p>
+      </section>
+
+      <section>
+        <h2>5. Destinataires</h2>
+        <p>Les informations sont destinées uniquement à l’équipe Navette Phoenix chargée du traitement des réservations et devis. Aucun transfert commercial ni revente n’est réalisé.</p>
+      </section>
+
+      <section>
+        <h2>6. Durée de conservation</h2>
+        <p>Les données sont conservées pendant une durée maximale de 12 mois après la réalisation du service, sauf obligation légale contraire.</p>
+      </section>
+
+      <section>
+        <h2>7. Hébergement et sécurité</h2>
+        <p>Les formulaires de l’application transmettent les données via un script Google Apps Script sécurisé (HTTPS). Nous appliquons des mesures techniques et organisationnelles pour protéger vos informations contre tout accès non autorisé.</p>
+      </section>
+
+      <section>
+        <h2>8. Droits des utilisateurs</h2>
+        <p>Conformément au RGPD, vous disposez des droits suivants :</p>
+        <ul>
+          <li>Droit d’accès, de rectification et d’effacement.</li>
+          <li>Droit d’opposition et de limitation du traitement.</li>
+          <li>Droit à la portabilité des données.</li>
+        </ul>
+        <p>Pour exercer vos droits, contactez-nous via <a href="mailto:Phoenix.lts28@navettephoenix.fr">Phoenix.lts28@navettephoenix.fr</a> ou par téléphone au <a href="tel:+33652758286">06&nbsp;52&nbsp;75&nbsp;82&nbsp;86</a>.</p>
+      </section>
+
+      <section>
+        <h2>9. Sous-traitants &amp; services tiers</h2>
+        <p>Nous utilisons Google Apps Script pour la gestion des formulaires. Le service est hébergé dans l’Union européenne lorsque cela est possible. Les données peuvent être transférées hors UE avec les garanties appropriées (clauses contractuelles types de Google).</p>
+      </section>
+
+      <section>
+        <h2>10. Mise à jour de la politique</h2>
+        <p>Nous pouvons modifier cette politique pour refléter l’évolution de nos services ou des obligations légales. Les utilisateurs seront informés des changements majeurs via l’application et le Play Store.</p>
+      </section>
+
+      <small>Pour toute question relative à cette politique de confidentialité, veuillez écrire à <a href="mailto:caro.resanavettephoenix@gmail.com">caro.resanavettephoenix@gmail.com</a>.</small>
+    </div>
+  </main>
+
+  <footer class="site-footer">
+    <div class="container footer-grid">
+      <p>&copy; <span id="current-year"></span> Navette Phoenix. Tous droits réservés.</p>
+      <nav aria-label="Liens de pied de page">
+        <a href="index.html">Accueil</a>
+        <a href="#top">Haut de page</a>
+      </nav>
+    </div>
+  </footer>
+
+  <script>
+    document.getElementById('current-year').textContent = new Date().getFullYear();
+    const date = new Date();
+    const formatter = new Intl.DateTimeFormat('fr-FR', { year: 'numeric', month: 'long', day: 'numeric' });
+    document.getElementById('privacy-date').textContent = formatter.format(date);
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- refresh the landing page with a 2×2 quick-action grid, floating labels, and updated orange gradient styling aligned to the Navette Phoenix charter
- add loader states plus a confirmation modal for the TAD and devis submissions while keeping Google Apps Script integration intact
- introduce an interactive trip comparison map using open routing data to estimate shuttle versus car durations for any pickup/drop-off pair

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68cd6b4ca30c832181880d09f30363f9