### PR TITLE
Initial Android app scaffold

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+/.gradle/
+/build/
+/captures/
+.externalNativeBuild/
+app/build/
+local.properties
+.DS_Store
+.idea/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,47 @@
-# navette-phoenix-site
+# Navette Phoenix
+
+Ce dépôt contient l&#39;application mobile Android *Navette Phoenix* ainsi que les ressources web historiques.
+
+## Prérequis
+
+* [Android Studio](https://developer.android.com/studio) Iguana ou plus récent.
+* JDK 17 ou 21.
+* Un Android SDK configuré (API 34 recommandé).
+
+## Ouvrir le projet
+
+1. Cloner ce dépôt.
+2. Dans Android Studio, choisir **Open** et sélectionner le dossier `navette-phoenix-site`.
+3. Laisser Android Studio effectuer la synchronisation Gradle.
+
+## Compilation en ligne de commande
+
+```bash
+# Depuis la racine du projet
+gradle wrapper --gradle-version 8.7.2   # Première fois uniquement si vous souhaitez générer le wrapper
+./gradlew assembleDebug                 # Compile l&#39;APK de debug
+```
+
+> **Remarque :** Si le SDK Android n&#39;est pas détecté automatiquement, configurez la variable `ANDROID_HOME` ou éditez le fichier `local.properties` pour y renseigner `sdk.dir=/chemin/vers/votre/sdk`.
+
+## Structure principale
+
+```
+navette-phoenix-site/
+├─ app/
+│  ├─ src/main/java/com/navettephoenix/
+│  │  ├─ data/        # Modèles et faux dépôts de données
+│  │  ├─ domain/      # Cas d&#39;usage (business)
+│  │  └─ ui/          # Activités et état d&#39;interface
+│  └─ src/main/res/   # Layouts, thèmes et ressources
+├─ build.gradle       # Configuration Gradle racine
+├─ settings.gradle    # Déclaration des modules
+└─ README.md
+```
+
+## Validation
+
+* Synchronisation Gradle : `gradle --refresh-dependencies help`
+* Compilation : `./gradlew assembleDebug`
+
+Des tâches supplémentaires (tests unitaires, lint, etc.) pourront être ajoutées par l&#39;équipe au fur et à mesure.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,0 +1,56 @@
+plugins {
+    id 'com.android.application'
+    id 'org.jetbrains.kotlin.android'
+}
+
+android {
+    namespace 'com.navettephoenix'
+    compileSdk 34
+
+    defaultConfig {
+        applicationId "com.navettephoenix"
+        minSdk 24
+        targetSdk 34
+        versionCode 1
+        versionName "1.0"
+
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+    }
+
+    buildTypes {
+        release {
+            isMinifyEnabled = false
+            proguardFiles(
+                getDefaultProguardFile('proguard-android-optimize.txt'),
+                'proguard-rules.pro'
+            )
+        }
+    }
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+    kotlinOptions {
+        jvmTarget = '1.8'
+    }
+
+    buildFeatures {
+        viewBinding true
+    }
+}
+
+dependencies {
+    implementation 'androidx.core:core-ktx:1.13.1'
+    implementation 'androidx.appcompat:appcompat:1.7.0'
+    implementation 'com.google.android.material:material:1.12.0'
+    implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
+    implementation 'androidx.coordinatorlayout:coordinatorlayout:1.2.0'
+    implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.8.6'
+    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.9.0'
+    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.9.0'
+
+    testImplementation 'junit:junit:4.13.2'
+    androidTestImplementation 'androidx.test.ext:junit:1.2.1'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.6.1'
+}

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -1,0 +1,6 @@
+# Add project specific ProGuard rules here.
+# You can control the set of applied configuration files using the
+# proguardFiles setting in build.gradle.
+
+# For more details, see
+#   http://developer.android.com/guide/developing/tools/proguard.html

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <application
+        android:allowBackup="true"
+        android:icon="@drawable/navette_logo"
+        android:label="@string/app_name"
+        android:supportsRtl="true"
+        android:theme="@style/Theme.NavettePhoenix">
+        <activity
+            android:name="com.navettephoenix.ui.MainActivity"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
+
+</manifest>

--- a/app/src/main/java/com/navettephoenix/data/model/NotificationMessage.kt
+++ b/app/src/main/java/com/navettephoenix/data/model/NotificationMessage.kt
@@ -1,0 +1,9 @@
+package com.navettephoenix.data.model
+
+data class NotificationMessage(
+    val id: String,
+    val title: String,
+    val body: String,
+    val timestamp: String,
+    val read: Boolean = false
+)

--- a/app/src/main/java/com/navettephoenix/data/model/Reservation.kt
+++ b/app/src/main/java/com/navettephoenix/data/model/Reservation.kt
@@ -1,0 +1,15 @@
+package com.navettephoenix.data.model
+
+data class Reservation(
+    val reservationId: String,
+    val passengerName: String,
+    val routeId: String,
+    val seats: Int,
+    val status: ReservationStatus
+)
+
+enum class ReservationStatus {
+    PENDING,
+    CONFIRMED,
+    CANCELLED
+}

--- a/app/src/main/java/com/navettephoenix/data/model/ShuttleRoute.kt
+++ b/app/src/main/java/com/navettephoenix/data/model/ShuttleRoute.kt
@@ -1,0 +1,16 @@
+package com.navettephoenix.data.model
+
+data class ShuttleRoute(
+    val id: String,
+    val departureTime: String,
+    val origin: String,
+    val destination: String,
+    val availableSeats: Int,
+    val status: ShuttleStatus
+)
+
+enum class ShuttleStatus {
+    BOARDING,
+    EN_ROUTE,
+    LANDED
+}

--- a/app/src/main/java/com/navettephoenix/data/repository/ShuttleRepository.kt
+++ b/app/src/main/java/com/navettephoenix/data/repository/ShuttleRepository.kt
@@ -1,0 +1,86 @@
+package com.navettephoenix.data.repository
+
+import com.navettephoenix.data.model.NotificationMessage
+import com.navettephoenix.data.model.Reservation
+import com.navettephoenix.data.model.ReservationStatus
+import com.navettephoenix.data.model.ShuttleRoute
+import com.navettephoenix.data.model.ShuttleStatus
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import java.util.UUID
+
+class ShuttleRepository {
+
+    private val routes = MutableStateFlow(generateRoutes())
+    private val notifications = MutableStateFlow<List<NotificationMessage>>(emptyList())
+
+    fun observeRoutes(): Flow<List<ShuttleRoute>> = routes.asStateFlow()
+
+    fun observeNotifications(): Flow<List<NotificationMessage>> = notifications.asStateFlow()
+
+    suspend fun createReservation(passengerName: String, seats: Int): Reservation {
+        delay(500)
+        val route = routes.value.first()
+        val reservation = Reservation(
+            reservationId = UUID.randomUUID().toString(),
+            passengerName = passengerName,
+            routeId = route.id,
+            seats = seats,
+            status = ReservationStatus.CONFIRMED
+        )
+        notifications.update { current ->
+            current + NotificationMessage(
+                id = UUID.randomUUID().toString(),
+                title = "Réservation confirmée",
+                body = "Votre navette pour ${route.destination} est prête.",
+                timestamp = "${System.currentTimeMillis()}"
+            )
+        }
+        routes.update { currentRoutes ->
+            currentRoutes.mapIndexed { index, shuttleRoute ->
+                if (index == 0) {
+                    shuttleRoute.copy(
+                        availableSeats = (shuttleRoute.availableSeats - seats).coerceAtLeast(0),
+                        status = ShuttleStatus.BOARDING
+                    )
+                } else {
+                    shuttleRoute
+                }
+            }
+        }
+        return reservation
+    }
+
+    suspend fun refreshRoutes() {
+        delay(350)
+        routes.update { current ->
+            current.map { route ->
+                if (route == current.first()) {
+                    route.copy(status = ShuttleStatus.BOARDING)
+                } else route
+            }
+        }
+    }
+
+    private fun generateRoutes(): List<ShuttleRoute> = listOf(
+        ShuttleRoute(
+            id = UUID.randomUUID().toString(),
+            departureTime = "08:30",
+            origin = "Centre-ville",
+            destination = "Aéroport",
+            availableSeats = 12,
+            status = ShuttleStatus.BOARDING
+        ),
+        ShuttleRoute(
+            id = UUID.randomUUID().toString(),
+            departureTime = "10:15",
+            origin = "Aéroport",
+            destination = "Centre-ville",
+            availableSeats = 18,
+            status = ShuttleStatus.LANDED
+        )
+    )
+}

--- a/app/src/main/java/com/navettephoenix/domain/usecase/CreateReservationUseCase.kt
+++ b/app/src/main/java/com/navettephoenix/domain/usecase/CreateReservationUseCase.kt
@@ -1,0 +1,10 @@
+package com.navettephoenix.domain.usecase
+
+import com.navettephoenix.data.model.Reservation
+import com.navettephoenix.data.repository.ShuttleRepository
+
+class CreateReservationUseCase(private val repository: ShuttleRepository) {
+    suspend operator fun invoke(passengerName: String, seats: Int): Reservation {
+        return repository.createReservation(passengerName, seats)
+    }
+}

--- a/app/src/main/java/com/navettephoenix/domain/usecase/GetUpcomingRoutesUseCase.kt
+++ b/app/src/main/java/com/navettephoenix/domain/usecase/GetUpcomingRoutesUseCase.kt
@@ -1,0 +1,9 @@
+package com.navettephoenix.domain.usecase
+
+import com.navettephoenix.data.model.ShuttleRoute
+import com.navettephoenix.data.repository.ShuttleRepository
+import kotlinx.coroutines.flow.Flow
+
+class GetUpcomingRoutesUseCase(private val repository: ShuttleRepository) {
+    operator fun invoke(): Flow<List<ShuttleRoute>> = repository.observeRoutes()
+}

--- a/app/src/main/java/com/navettephoenix/domain/usecase/ObserveNotificationsUseCase.kt
+++ b/app/src/main/java/com/navettephoenix/domain/usecase/ObserveNotificationsUseCase.kt
@@ -1,0 +1,9 @@
+package com.navettephoenix.domain.usecase
+
+import com.navettephoenix.data.model.NotificationMessage
+import com.navettephoenix.data.repository.ShuttleRepository
+import kotlinx.coroutines.flow.Flow
+
+class ObserveNotificationsUseCase(private val repository: ShuttleRepository) {
+    operator fun invoke(): Flow<List<NotificationMessage>> = repository.observeNotifications()
+}

--- a/app/src/main/java/com/navettephoenix/ui/MainActivity.kt
+++ b/app/src/main/java/com/navettephoenix/ui/MainActivity.kt
@@ -1,0 +1,139 @@
+package com.navettephoenix.ui
+
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
+import com.google.android.material.snackbar.Snackbar
+import com.navettephoenix.R
+import com.navettephoenix.data.model.ShuttleStatus
+import com.navettephoenix.data.repository.ShuttleRepository
+import com.navettephoenix.databinding.ActivityMainBinding
+import com.navettephoenix.domain.usecase.CreateReservationUseCase
+import com.navettephoenix.domain.usecase.GetUpcomingRoutesUseCase
+import com.navettephoenix.domain.usecase.ObserveNotificationsUseCase
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
+
+class MainActivity : AppCompatActivity() {
+
+    private lateinit var binding: ActivityMainBinding
+
+    private val repository = ShuttleRepository()
+    private val getUpcomingRoutes = GetUpcomingRoutesUseCase(repository)
+    private val createReservation = CreateReservationUseCase(repository)
+    private val observeNotifications = ObserveNotificationsUseCase(repository)
+
+    private var uiState: ShuttleUiState = ShuttleUiState()
+    private var stateCollectionJob: Job? = null
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        binding = ActivityMainBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+        setSupportActionBar(binding.toolbar)
+
+        setupListeners()
+        observeShuttleData()
+    }
+
+    private fun setupListeners() {
+        binding.reserveButton.setOnClickListener {
+            lifecycleScope.launch {
+                binding.reserveButton.isEnabled = false
+                createReservation(passengerName = "Invité", seats = 1)
+                uiState = uiState.copy(
+                    lastReservationMessage = getString(R.string.status_reservation_confirmed)
+                )
+                renderState(uiState)
+                Snackbar.make(
+                    binding.root,
+                    getString(R.string.message_reservation),
+                    Snackbar.LENGTH_LONG
+                ).show()
+                binding.reserveButton.isEnabled = true
+            }
+        }
+
+        binding.viewScheduleButton.setOnClickListener {
+            Snackbar.make(binding.root, R.string.message_schedule, Snackbar.LENGTH_SHORT).show()
+        }
+
+        binding.notificationsButton.setOnClickListener {
+            val message = if (uiState.notifications.isEmpty()) {
+                getString(R.string.message_notifications)
+            } else {
+                uiState.notifications.first().body
+            }
+            Snackbar.make(binding.root, message, Snackbar.LENGTH_SHORT).show()
+        }
+    }
+
+    private fun observeShuttleData() {
+        stateCollectionJob?.cancel()
+        stateCollectionJob = lifecycleScope.launch {
+            repeatOnLifecycle(Lifecycle.State.STARTED) {
+                uiState = uiState.copy(isLoading = true)
+                renderState(uiState)
+
+                launch {
+                    getUpcomingRoutes().collect { routes ->
+                        uiState = uiState.copy(
+                            routes = routes,
+                            isLoading = false,
+                            errorMessage = null
+                        )
+                        renderState(uiState)
+                    }
+                }
+
+                launch {
+                    observeNotifications().collect { notifications ->
+                        uiState = uiState.copy(notifications = notifications)
+                        renderState(uiState)
+                    }
+                }
+
+                launch {
+                    repository.refreshRoutes()
+                }
+            }
+        }
+    }
+
+    private fun renderState(state: ShuttleUiState) {
+        val nextRoute = state.routes.firstOrNull()
+        val departureText = if (nextRoute != null) {
+            getString(
+                R.string.next_departure_format,
+                nextRoute.departureTime,
+                nextRoute.origin,
+                nextRoute.destination,
+                nextRoute.availableSeats
+            )
+        } else {
+            getString(R.string.status_loading)
+        }
+        binding.nextDepartureText.text = departureText
+
+        val chipText = when {
+            state.isLoading -> getString(R.string.status_loading)
+            nextRoute == null -> getString(R.string.status_loading)
+            nextRoute.status == ShuttleStatus.BOARDING -> getString(R.string.status_ready)
+            else -> nextRoute.status.name.lowercase().replaceFirstChar { it.titlecase() }
+        }
+        binding.statusChip.text = chipText
+
+        val notificationsCount = state.notifications.size
+        val baseLabel = getString(R.string.action_notifications)
+        binding.notificationsButton.text =
+            if (notificationsCount > 0) "$baseLabel (${notificationsCount})" else baseLabel
+
+        state.lastReservationMessage?.let {
+            binding.statusChip.text = getString(R.string.status_reservation_confirmed)
+        }
+
+        binding.reserveButton.isEnabled = !state.isLoading
+    }
+}

--- a/app/src/main/java/com/navettephoenix/ui/ShuttleUiState.kt
+++ b/app/src/main/java/com/navettephoenix/ui/ShuttleUiState.kt
@@ -1,0 +1,12 @@
+package com.navettephoenix.ui
+
+import com.navettephoenix.data.model.NotificationMessage
+import com.navettephoenix.data.model.ShuttleRoute
+
+data class ShuttleUiState(
+    val isLoading: Boolean = true,
+    val routes: List<ShuttleRoute> = emptyList(),
+    val notifications: List<NotificationMessage> = emptyList(),
+    val lastReservationMessage: String? = null,
+    val errorMessage: String? = null
+)

--- a/app/src/main/res/drawable/navette_logo.xml
+++ b/app/src/main/res/drawable/navette_logo.xml
@@ -1,0 +1,15 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="108dp"
+    android:height="108dp"
+    android:viewportWidth="108"
+    android:viewportHeight="108">
+    <path
+        android:fillColor="#FF6F00"
+        android:pathData="M12,72c0,-16 16,-36 42,-36s42,20 42,36c0,16 -16,30 -42,30s-42,-14 -42,-30z" />
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M30,62h48l8,16h-64z" />
+    <path
+        android:fillColor="#FF6F00"
+        android:pathData="M40,58l8,-12h12l8,12z" />
+</vector>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".ui.MainActivity">
+
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="?attr/colorPrimary"
+        android:title="@string/app_name"
+        android:titleTextColor="@android:color/white"
+        app:layout_scrollFlags="scroll|enterAlways" />
+
+    <ScrollView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_marginTop="?attr/actionBarSize"
+        android:padding="24dp"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:gravity="center_horizontal"
+            android:orientation="vertical"
+            android:paddingBottom="32dp"
+            android:paddingTop="16dp">
+
+            <ImageView
+                android:id="@+id/logoImage"
+                android:layout_width="120dp"
+                android:layout_height="120dp"
+                android:layout_marginBottom="24dp"
+                android:contentDescription="@string/content_description_logo"
+                android:src="@drawable/navette_logo" />
+
+            <TextView
+                android:id="@+id/welcomeText"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="16dp"
+                android:gravity="center"
+                android:text="@string/welcome_title"
+                android:textAlignment="center"
+                android:textAppearance="@style/TextAppearance.Material3.DisplaySmall" />
+
+            <com.google.android.material.chip.Chip
+                android:id="@+id/statusChip"
+                style="@style/Widget.Material3.Chip.Assist"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="24dp"
+                android:text="@string/status_loading"
+                app:chipBackgroundColor="@color/brand_secondary"
+                app:chipIcon="@drawable/navette_logo"
+                app:chipIconSize="20dp"
+                app:chipIconTint="@android:color/white" />
+
+            <TextView
+                android:id="@+id/nextDepartureTitle"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="4dp"
+                android:text="@string/next_departure_title"
+                android:textAppearance="@style/TextAppearance.Material3.TitleLarge" />
+
+            <TextView
+                android:id="@+id/nextDepartureText"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="24dp"
+                android:gravity="center"
+                android:textAlignment="center"
+                android:textAppearance="@style/TextAppearance.Material3.BodyLarge"
+                tools:text="Prochain départ à 08:30 vers Aéroport" />
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/reserveButton"
+                style="@style/Widget.Material3.Button"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="12dp"
+                android:text="@string/action_reserve" />
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/viewScheduleButton"
+                style="@style/Widget.Material3.Button.Elevated"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="12dp"
+                android:text="@string/action_view_schedule" />
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/notificationsButton"
+                style="@style/Widget.Material3.Button.Outlined"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/action_notifications" />
+        </LinearLayout>
+    </ScrollView>
+
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/values-night/themes.xml
+++ b/app/src/main/res/values-night/themes.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style name="Theme.NavettePhoenix" parent="Theme.Material3.Dark.NoActionBar">
+        <item name="colorPrimary">@color/brand_secondary</item>
+        <item name="colorSecondary">@color/brand_primary</item>
+        <item name="android:windowBackground">#121212</item>
+        <item name="android:textColorPrimary">@color/brand_on_primary</item>
+        <item name="android:textColorSecondary">@color/brand_on_secondary</item>
+        <item name="android:windowLightStatusBar">false</item>
+        <item name="android:windowLightNavigationBar">false</item>
+    </style>
+</resources>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <color name="brand_primary">#FF6F00</color>
+    <color name="brand_secondary">#1976D2</color>
+    <color name="brand_background">#FFF8E1</color>
+    <color name="brand_on_primary">#FFFFFF</color>
+    <color name="brand_on_secondary">#FFFFFF</color>
+</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">Navette Phoenix</string>
+    <string name="welcome_title">Bienvenue à bord de la Navette Phoenix</string>
+    <string name="next_departure_title">Prochain départ</string>
+    <string name="next_departure_format">Départ à %1$s depuis %2$s vers %3$s · %4$d places disponibles</string>
+    <string name="status_loading">Mise à jour des informations...</string>
+    <string name="status_ready">Navette prête pour l&#39;embarquement</string>
+    <string name="status_reservation_confirmed">Réservation confirmée</string>
+    <string name="action_reserve">Réserver un trajet</string>
+    <string name="action_view_schedule">Consulter les horaires</string>
+    <string name="action_notifications">Notifications</string>
+    <string name="message_reservation">Votre demande de réservation a été transmise.</string>
+    <string name="message_schedule">Les horaires complets sont disponibles dans l&#39;application partenaire.</string>
+    <string name="message_notifications">Aucune nouvelle notification.</string>
+    <string name="content_description_logo">Logo Navette Phoenix</string>
+</resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:tools="http://schemas.android.com/tools">
+    <style name="Theme.NavettePhoenix" parent="Theme.Material3.Light.NoActionBar">
+        <item name="colorPrimary">@color/brand_primary</item>
+        <item name="colorSecondary">@color/brand_secondary</item>
+        <item name="android:statusBarColor">@color/brand_secondary</item>
+        <item name="android:navigationBarColor">@color/brand_secondary</item>
+        <item name="android:windowBackground">@color/brand_background</item>
+        <item name="android:textColorPrimary">@color/brand_on_primary</item>
+        <item name="android:textColorSecondary">@color/brand_on_secondary</item>
+        <item name="android:fontFamily">sans-serif</item>
+        <item name="android:windowLightStatusBar">false</item>
+        <item name="android:windowLightNavigationBar">false</item>
+    </style>
+</resources>

--- a/build.gradle
+++ b/build.gradle
@@ -1,0 +1,8 @@
+plugins {
+    id 'com.android.application' version '8.7.2' apply false
+    id 'org.jetbrains.kotlin.android' version '1.9.24' apply false
+}
+
+tasks.register('clean', Delete) {
+    delete rootProject.layout.buildDirectory
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,0 +1,18 @@
+pluginManagement {
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
+
+rootProject.name = "NavettePhoenix"
+include(":app")


### PR DESCRIPTION
## Summary
- add Android application module with Gradle configuration, namespace `com.navettephoenix`, and required dependencies
- implement Navette Phoenix main screen layout, activity logic, and supporting data/domain scaffolding for routes, reservations, and notifications
- document build prerequisites and workflow in README and add repository ignores

## Testing
- `gradle help` *(fails: com.android.application plugin cannot be resolved in offline environment)*
- `gradle wrapper --gradle-version 8.7.2` *(fails: com.android.application plugin cannot be resolved in offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d456a20d948321a86c7f40e3b8dd6c