### PR TITLE
Update contact email addresses to phoenix.lts28@gmail.com

### DIFF
--- a/assets/script.js
+++ b/assets/script.js
@@ -194,7 +194,7 @@ const handleSubmit = (event) => {
 
   if (form.id === 'tad-form' || form.id === 'devis-form') {
     payload.recipient_email = 'caro.resanavettephoenix@gmail.com';
-    payload.manager_email = 'Phoenix.lts28@navettephoenix.fr';
+    payload.manager_email = 'phoenix.lts28@gmail.com';
   }
 
   fetch(appsScriptUrl, {

--- a/index.html
+++ b/index.html
@@ -174,7 +174,7 @@
             <li><strong>Réservations :</strong> <a href="tel:+33652758286">06&nbsp;52&nbsp;75&nbsp;82&nbsp;86</a></li>
             <li><strong>Informations :</strong> <a href="tel:+33685704336">06&nbsp;85&nbsp;70&nbsp;43&nbsp;36</a></li>
             <li><strong>E-mail TAD :</strong> <a href="mailto:caro.resanavettephoenix@gmail.com">caro.resanavettephoenix@gmail.com</a></li>
-            <li><strong>Réclamations :</strong> <a href="mailto:Phoenix.lts28@navettephoenix.fr">Phoenix.lts28@navettephoenix.fr</a></li>
+            <li><strong>Réclamations :</strong> <a href="mailto:phoenix.lts28@gmail.com">phoenix.lts28@gmail.com</a></li>
           </ul>
         </article>
       </div>
@@ -427,7 +427,7 @@
             <li><strong>E-mail réservation :</strong> <a href="mailto:caro.resanavettephoenix@gmail.com">caro.resanavettephoenix@gmail.com</a></li>
             <li>
               <strong>Renseignement &amp; réclamation :</strong>
-              <a href="mailto:Phoenix.lts28@navettephoenix.fr">Phoenix.lts28@navettephoenix.fr</a>
+              <a href="mailto:phoenix.lts28@gmail.com">phoenix.lts28@gmail.com</a>
             </li>
           </ul>
         </div>

--- a/privacy.html
+++ b/privacy.html
@@ -93,7 +93,7 @@
           <li>Droit d’opposition et de limitation du traitement.</li>
           <li>Droit à la portabilité des données.</li>
         </ul>
-        <p>Pour exercer vos droits, contactez-nous via <a href="mailto:Phoenix.lts28@navettephoenix.fr">Phoenix.lts28@navettephoenix.fr</a> ou par téléphone au <a href="tel:+33652758286">06&nbsp;52&nbsp;75&nbsp;82&nbsp;86</a>.</p>
+        <p>Pour exercer vos droits, contactez-nous via <a href="mailto:phoenix.lts28@gmail.com">phoenix.lts28@gmail.com</a> ou par téléphone au <a href="tel:+33652758286">06&nbsp;52&nbsp;75&nbsp;82&nbsp;86</a>.</p>
       </section>
 
       <section>


### PR DESCRIPTION
## Summary
- update all contact links for the réclamation address to use phoenix.lts28@gmail.com
- send form manager notifications to the new gmail inbox
- align privacy policy contact email with the updated mailbox

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dee97625dc832190d58d648aff5724